### PR TITLE
T254212 Fix mouse leave event

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -32,7 +32,8 @@ const createPopup = (container, win=window) => {
 		container.appendChild(popup)
 	}
 
-	const onMouseLeave = ({toElement}) => {
+	const onMouseLeave = e => {
+		const toElement = e.toElement || e.relatedTarget
 		if (toElement !== currentTargetElement && !popup.contains(toElement)) {
 			popup.style.visibility = 'hidden'
 			if (currentTargetElement) {


### PR DESCRIPTION
Phabricator ticket : https://phabricator.wikimedia.org/T254212

Problem
===

The popup close immediately as soon as the mouse leaving the hover target element

Solution
===

FF doesn't have `event.toElement`, use `event.relatedTarget` instead

Note
===

it works on Firefox 77 / Firefox 58 (older)
