### PR TITLE
T243774 use responseText instead response in xmlHttpRequest in IE

### DIFF
--- a/src/cachedRequest.js
+++ b/src/cachedRequest.js
@@ -1,11 +1,10 @@
 
 const request = (url, callback) => {
 	const xhr = new XMLHttpRequest()
-	xhr.responseType = 'json'
 	xhr.open('GET', url)
 	xhr.send()
 	xhr.addEventListener('load', () => {
-		callback(xhr.response)
+		callback(JSON.parse(xhr.responseText))
 	})
 	xhr.addEventListener('error', () => {
 		callback(null, xhr.status)


### PR DESCRIPTION
the `cachedRequest` doesn't work in IE due to the missing support of `xhr.responseType = 'json'`, therefore use `xhr.responseText` to cover older version browser

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseText

Browser Compability of responseType
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType